### PR TITLE
Only show the modal once per session

### DIFF
--- a/coinhive.js
+++ b/coinhive.js
@@ -1,39 +1,51 @@
 // Credit to https://w3bits.com/javascript-modal/
 
 let createModal = (modalContent) => {
-  let modal = document.createElement("div"),
-    modalStyle = document.createElement("style"),
-    modalCSS = '.js-modal{ position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, .8); width: 100%; height: 100%; z-index: 999999; } .js-modal-inner{ background-color: rgba(174, 145, 93, .9); position: relative; padding: 50px; font-size: 24px; max-width: 650px; top: 50%; left: 50%; transform: translate(-50%, -50%); color: #000; border-radius: 10px; font-family: Arial, Tahoma, Helvetica, FreeSans, sans-serif; line-height: normal; text-align: center; }  .js-modal-inner a { color: #000; text-decoration: underline; } .js-modal-close{ position: absolute; top: -10px; right: -10px; background-color: black; color: #eee; border-width: 0; font-size: 10px; height: 24px; width: 24px; border-radius: 100%; text-align: center; font-family: Arial; }',
-    modalClose = '<button class="js-modal-close" id="js_modal_close">X</button>',
-    theBody = document.getElementsByTagName('body')[0],
-    theHead = document.getElementsByTagName('head')[0];
+    let modal      = document.createElement('div'),
+        modalStyle = document.createElement('style'),
+        modalCSS   = '.js-modal{ position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: rgba(0, 0, 0, .8); width: 100%; height: 100%; z-index: 999999; } .js-modal-inner{ background-color: rgba(174, 145, 93, .9); position: relative; padding: 50px; font-size: 24px; max-width: 650px; top: 50%; left: 50%; transform: translate(-50%, -50%); color: #000; border-radius: 10px; font-family: Arial, Tahoma, Helvetica, FreeSans, sans-serif; line-height: normal; text-align: center; }  .js-modal-inner a { color: #000; text-decoration: underline; } .js-modal-close{ position: absolute; top: -10px; right: -10px; background-color: black; color: #eee; border-width: 0; font-size: 10px; height: 24px; width: 24px; border-radius: 100%; text-align: center; font-family: Arial; }',
+        modalClose = document.createElement('button'),
+        modalInner = document.createElement('div'),
+        theBody    = document.getElementsByTagName('body')[0],
+        theHead    = document.getElementsByTagName('head')[0];
 
-  // Add content and attributes to the modal
-  modal.setAttribute("class", "js-modal");
-  modal.innerHTML = '<div class="js-modal-inner">' + modalContent + modalClose + '</div>';
-  theBody.appendChild(modal);
+    modalClose.classList.add('js-modal-close');
+    modalClose.innerText = 'X';
 
-  modalClose = document.querySelector("#js_modal_close");
+    modalInner.classList.add('js-modal-inner');
+    modalInner.innerHTML = modalContent;
 
-  // Add the modal styles dynamically
-  if(modalStyle.styleSheet){
-    modalStyle.styleSheet.cssText = modalCSS;
-  } else {
-    modalStyle.appendChild(document.createTextNode(modalCSS));
-  }
-  theHead.appendChild(modalStyle);
+    modalInner.appendChild(modalClose);
 
-  // Close the modal on button-click
-  if(modalClose) {
-    modalClose.addEventListener('click', function() {
-      modal.remove();
-      modalStyle.remove();
-    });
-  }
+    // Add content and attributes to the modal
+    modal.classList.add('js-modal');
+    modal.appendChild(modalInner);
+
+    theBody.appendChild(modal);
+
+    // Add the modal styles dynamically
+    if (modalStyle.styleSheet) {
+        modalStyle.styleSheet.cssText = modalCSS;
+    } else {
+        modalStyle.appendChild(document.createTextNode(modalCSS));
+    }
+
+    theHead.appendChild(modalStyle);
+
+    // Close the modal on button-click
+    if (modalClose) {
+        modalClose.addEventListener('click', function () {
+            modal.remove();
+            modalStyle.remove();
+            sessionStorage.setItem('coinhive-modal-shown', '1');
+        });
+    }
 }
 
-// Show it up when loading starts
-window.addEventListener('load', function() {
-  /* Remember to escape the characters to their respective valid HTML entities, for eg. ' will become \' */
-  createModal('This website attempted to run a cryptominer in your browser. <a href="https://www.troyhunt.com/i-now-own-the-coinhive-domain-heres-how-im-fighting-cryptojacking-and-doing-good-things-with-content-security-policies">Click here for more information</a>.');
-});
+if (sessionStorage.getItem('coinhive-modal-shown') === null) {
+    // Show it up when loading starts
+    window.addEventListener('load', function () {
+        /* Remember to escape the characters to their respective valid HTML entities, for eg. ' will become \' */
+        createModal('This website attempted to run a cryptominer in your browser. <a href="https://www.troyhunt.com/i-now-own-the-coinhive-domain-heres-how-im-fighting-cryptojacking-and-doing-good-things-with-content-security-policies">Click here for more information</a>.');
+    });
+}

--- a/coinhive.js
+++ b/coinhive.js
@@ -32,14 +32,23 @@ let createModal = (modalContent) => {
 
     theHead.appendChild(modalStyle);
 
+    const keydownEventListener = event => {
+        if (event.key === 'Escape') {
+            closeModal();
+        }
+    };
+
+    const closeModal = () => {
+        modal.remove();
+        modalStyle.remove();
+        sessionStorage.setItem('coinhive-modal-shown', '1');
+        theBody.removeEventListener('keydown', keydownEventListener)
+    };
+
     // Close the modal on button-click
-    if (modalClose) {
-        modalClose.addEventListener('click', function () {
-            modal.remove();
-            modalStyle.remove();
-            sessionStorage.setItem('coinhive-modal-shown', '1');
-        });
-    }
+    modalClose.addEventListener('click', closeModal);
+
+    theBody.addEventListener('keydown', keydownEventListener);
 }
 
 if (sessionStorage.getItem('coinhive-modal-shown') === null) {


### PR DESCRIPTION
Hi Troy, I appreciate the work you do a lot – I remember you once indirectly took down my website by Tweeting a link to it, the modern Slashdot effect 🤣. I thought I'd help out a bit. I made the script a bit more friendly for the users who've suddenly been greeted by this modal; It now only shows up once per browsing session (well, if you press the close button or the Escape key on your keyboard at least). This would allow the users to continue browsing the website further on after they've acknowledged the message. As mentioned before, the modal can now also be closed by pressing the Escape key on your keyboard.

Also, just like #1 my commit has made the quotation style a bit more consistent, nothing major. I've also changed the way the event listener is added to the close button to make it a bit more consistent as well.